### PR TITLE
DEV-923 (internal) fix(splat): wipe tmp directory after run

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -407,6 +407,12 @@ def lambda_handler(event: dict, context: dict) -> dict:  # noqa
     except Exception as e:
         logger.error(f"splat|unknown_error|{str(e)}|stacktrace:", exc_info=True)
         resp = SplatPDFGenerationFailure(status_code=500, message=str(e)).as_response().as_dict()
+    finally:
+        try:
+            execute(["rm", "-rf", "/tmp/*"])  # noqa
+        except Exception as e:
+            logger.error(f"splat|cleanup_error|{str(e)}|stacktrace:", exc_info=True)
+
     return resp
 
 


### PR DESCRIPTION
Just nuking with a try-catch, couldn't exactly pin down how / if playwright is at fault

![image](https://github.com/user-attachments/assets/f102e6e3-ca74-4cdd-a5c1-525611eb9219)

Feel like we should also be cleaning up in workforce too, not sure why we leave these hanging for a week if unsuccessful:
![Screenshot 2024-11-13 at 1 27 51 PM](https://github.com/user-attachments/assets/4f1d7f38-f51c-4446-8548-83f1d2255861)
