### PR TITLE
chore(sec-65): widen Django dependency constraint to <6.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "django>=5.0, <5.2",
+    "django>=5.0, <6.1",
     "boto3",
     "playwright==1.43.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,7 @@ wheels = [
 
 [[package]]
 name = "uptick-splat"
-version = "0.4.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -366,7 +366,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "boto3" },
-    { name = "django", specifier = ">=5.0,<5.2" },
+    { name = "django", specifier = ">=5.0,<6.1" },
     { name = "playwright", specifier = "==1.43.0" },
 ]
 


### PR DESCRIPTION
## Summary
- Widens the Django dependency constraint from `>=5.0, <5.2` to `>=5.0, <6.1`
- The `uptick_splat` client library doesn't actually import Django — the constraint is purely informational for consumers
- Allows consumers to upgrade to Django 5.2+ without being blocked by splat

## Test plan
- [x] Verified `uptick_splat/` has no Django imports
- [ ] Confirm existing consumers work with Django 5.2+

🤖 Generated with [Claude Code](https://claude.com/claude-code)